### PR TITLE
Compatibility with ggplot2 3.6.0

### DIFF
--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -221,6 +221,11 @@ test_that("geom_freq_by_year_ci works correctly", {
     )
     gpt <- df %>% ggplot(aes(year, ipm, fill = condition, color = condition)) +
       geom_freq_by_year_ci()
-    expect_equal(gpt[["labels"]][["url"]], "webUIRequestUrl")
+    labels <- if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+      ggplot2::get_labs(gpt)
+    } else {
+      gpt[["labels"]]
+    }
+    expect_equal(labels[["url"]], "webUIRequestUrl")
     expect_equal(gpt[["data"]][["query"]][14], "[tt/l=Heuschrecke]")
 })


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the RKorAPClient package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

This PR changes the tests to be compatible with both versions of ggplot2. 
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun